### PR TITLE
nicer versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "dependencies": {
     "common-tags": "^1.8.2",
     "socialagi": "~0.1.7",
-    "soul-engine": "~0.0.29"
+    "soul-engine": "~0.0.39"
   }
 }


### PR DESCRIPTION
just brings the versioning of soul-engine up... this shouldn't actually affect what's been installed because of the `~`