### PR TITLE
bump versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "common-tags": "^1.8.2",
-    "socialagi": "~0.1.7",
-    "soul-engine": "~0.0.39"
+    "socialagi": "~0.1.9",
+    "soul-engine": "~0.0.47"
   }
 }


### PR DESCRIPTION
just bump the two versions. Because of the tilde it shouldn't matter much, but good to keep it up to date.